### PR TITLE
feat: Add "Assigned" status and notify on reassignment

### DIFF
--- a/src/commands/utility/assignMeTaskThread.js
+++ b/src/commands/utility/assignMeTaskThread.js
@@ -3,7 +3,7 @@ const { DISCORD_SERVER } = require('../../config');
 const { translateLanguage } = require('../../languages/index');
 
 const ASSIGN_EMOJI = '⚔';
-const ASSIGNED_PATTERN = new RegExp(`|${ASSIGN_EMOJI} @[w-]+|`);
+const ASSIGNED_PATTERN = new RegExp(`\\|${ASSIGN_EMOJI} @[\\w-]+\\|`);
 const userAssignedPattern = (username) =>
   new RegExp(`\\|${ASSIGN_EMOJI} \\@(${username})\\|`, 'g');
 const generateAssignedThreadName = (username) =>

--- a/src/commands/utility/assignMeTaskThread.js
+++ b/src/commands/utility/assignMeTaskThread.js
@@ -15,7 +15,6 @@ const getAssignReply = async ({ originalChannelName, user, client }) => {
   if (originalChannelName.includes(currentUserAssignationString)) {
     return {
       content: translateLanguage('tasksThread.taskAssigned'),
-      ephemeral: true,
     };
   }
 
@@ -57,12 +56,11 @@ module.exports = {
   async execute(interaction) {
     try {
       const { channel, client, user } = interaction;
-      await interaction.deferReply({ ephemeral: true });
+      await interaction.deferReply();
 
       if (!channel.isThread()) {
         return await interaction.editReply({
           content: translateLanguage('changeStatus.notAThread'),
-          ephemeral: true,
         });
       }
       const channelName = channel.name;
@@ -70,7 +68,10 @@ module.exports = {
         { client, originalChannelName: channelName, user }
       );
 
-      await channel.setName(updatedChannelName);
+      if (updatedChannelName) {
+        await channel.setName(updatedChannelName);
+      }
+
       await interaction.editReply({
         content,
       });

--- a/src/commands/utility/assignMeTaskThread.js
+++ b/src/commands/utility/assignMeTaskThread.js
@@ -3,14 +3,17 @@ const { DISCORD_SERVER } = require('../../config');
 const { translateLanguage } = require('../../languages/index');
 
 const ASSIGN_EMOJI = '⚔';
-const ASSIGNED_PATTERN = /\|⚔ @[\w-]+\|/;
+const ASSIGNED_PATTERN = new RegExp(`|${ASSIGN_EMOJI} @[w-]+|`);
 const userAssignedPattern = (username) =>
   new RegExp(`\\|${ASSIGN_EMOJI} \\@(${username})\\|`, 'g');
+const generateAssignedThreadName = (username) =>
+  `|${ASSIGN_EMOJI} @${username}|`;
 
 const getAssignReply = async ({ originalChannelName, user, client }) => {
   const assignedUsername = user.username;
   const escapedNewUserId = `<@${user.id}>`;
-  const currentUserAssignationString = `|${ASSIGN_EMOJI} @${assignedUsername}|`;
+  const currentUserAssignationString =
+    generateAssignedThreadName(assignedUsername);
 
   if (originalChannelName.includes(currentUserAssignationString)) {
     return {
@@ -35,7 +38,7 @@ const getAssignReply = async ({ originalChannelName, user, client }) => {
   );
   const escapedOriginalUserId = `<@${previousAssignedMember?.id}>`;
   const previousAssignedUsername = previousAssignedMember?.user?.username;
-  const userAssignationString = `|${ASSIGN_EMOJI} @${assignedUsername}|`;
+  const userAssignationString = generateAssignedThreadName(assignedUsername);
   const updatedChannelName = `${userAssignationString} ${originalChannelName.replace(userAssignedPattern(previousAssignedUsername), '')}`;
 
   return {

--- a/src/commands/utility/assignMeTaskThread.js
+++ b/src/commands/utility/assignMeTaskThread.js
@@ -1,0 +1,90 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { DISCORD_SERVER } = require('../../config');
+const { translateLanguage } = require('../../languages/index');
+
+const ASSIGN_EMOJI = '⚔';
+const ASSIGNED_PATTERN = /\|⚔ @[\w-]+\|/;
+const userAssignedPattern = (username) =>
+  new RegExp(`\\|${ASSIGN_EMOJI} \\@(${username})\\|`, 'g');
+
+const getAssignReply = async ({ originalChannelName, user, client }) => {
+  const assignedUsername = user.username;
+  const escapedNewUserId = `<@${user.id}>`;
+  const currentUserAssignationString = `|${ASSIGN_EMOJI} @${assignedUsername}|`;
+
+  if (originalChannelName.includes(currentUserAssignationString)) {
+    return {
+      content: translateLanguage('tasksThread.taskAssigned'),
+      ephemeral: true,
+    };
+  }
+
+  if (originalChannelName.search(ASSIGNED_PATTERN) < 0) {
+    const updatedChannelName = `${currentUserAssignationString} ${originalChannelName}`;
+
+    return {
+      channelName: updatedChannelName,
+      content: translateLanguage('tasksThread.taskAssignedTo', {
+        newUserId: escapedNewUserId,
+      }),
+    };
+  }
+
+  const guild = await client.guilds.fetch(DISCORD_SERVER.discordGuildId);
+  const members = await guild.members.fetch();
+  const previousAssignedMember = members.find(
+    (member) =>
+      originalChannelName.search(userAssignedPattern(member.user.username)) >= 0
+  );
+  const escapedOriginalUserId = `<@${previousAssignedMember?.id}>`;
+  const previousAssignedUsername = previousAssignedMember?.user?.username;
+  const userAssignationString = `|${ASSIGN_EMOJI} @${assignedUsername}|`;
+  const updatedChannelName = `${userAssignationString} ${originalChannelName.replace(userAssignedPattern(previousAssignedUsername), '')}`;
+  const hasPreviousAssign =
+    previousAssignedMember && previousAssignedUsername !== user.username;
+
+  return {
+    channelName: updatedChannelName,
+    content: hasPreviousAssign
+      ? translateLanguage('tasksThread.reassignedTaskTo', {
+          originalUserAssigned: escapedOriginalUserId,
+          newUserAssigned: escapedNewUserId,
+        })
+      : translateLanguage('tasksThread.taskAssignedTo', {
+          newUserId: escapedNewUserId,
+        }),
+  };
+};
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('assign-me')
+    .setDescription(
+      'Mark a task as assigned and define the name of the user that is assigned in the thread'
+    ),
+  async execute(interaction) {
+    try {
+      const { channel, client, user } = interaction;
+      await interaction.deferReply({ ephemeral: true });
+
+      if (!channel.isThread()) {
+        return await interaction.editReply({
+          content: translateLanguage('changeStatus.notAThread'),
+          ephemeral: true,
+        });
+      }
+      const channelName = channel.name;
+      const { channelName: updatedChannelName, content } = await getAssignReply(
+        { client, originalChannelName: channelName, user }
+      );
+
+      await channel.setName(updatedChannelName);
+      await interaction.editReply({
+        content,
+      });
+    } catch (error) {
+      console.error(error);
+      await interaction.editReply(translateLanguage('changeStatus.error'));
+    }
+  },
+};

--- a/src/commands/utility/assignMeTaskThread.js
+++ b/src/commands/utility/assignMeTaskThread.js
@@ -20,10 +20,8 @@ const getAssignReply = async ({ originalChannelName, user, client }) => {
   }
 
   if (originalChannelName.search(ASSIGNED_PATTERN) < 0) {
-    const updatedChannelName = `${currentUserAssignationString} ${originalChannelName}`;
-
     return {
-      channelName: updatedChannelName,
+      channelName: `${currentUserAssignationString} ${originalChannelName}`,
       content: translateLanguage('tasksThread.taskAssignedTo', {
         newUserId: escapedNewUserId,
       }),
@@ -40,19 +38,13 @@ const getAssignReply = async ({ originalChannelName, user, client }) => {
   const previousAssignedUsername = previousAssignedMember?.user?.username;
   const userAssignationString = `|${ASSIGN_EMOJI} @${assignedUsername}|`;
   const updatedChannelName = `${userAssignationString} ${originalChannelName.replace(userAssignedPattern(previousAssignedUsername), '')}`;
-  const hasPreviousAssign =
-    previousAssignedMember && previousAssignedUsername !== user.username;
 
   return {
     channelName: updatedChannelName,
-    content: hasPreviousAssign
-      ? translateLanguage('tasksThread.reassignedTaskTo', {
-          originalUserAssigned: escapedOriginalUserId,
-          newUserAssigned: escapedNewUserId,
-        })
-      : translateLanguage('tasksThread.taskAssignedTo', {
-          newUserId: escapedNewUserId,
-        }),
+    content: translateLanguage('tasksThread.reassignedTaskTo', {
+      originalUserAssigned: escapedOriginalUserId,
+      newUserAssigned: escapedNewUserId,
+    }),
   };
 };
 

--- a/src/commands/utility/assignMeTaskThread.js
+++ b/src/commands/utility/assignMeTaskThread.js
@@ -53,9 +53,7 @@ const getAssignReply = async ({ originalChannelName, user, client }) => {
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('assign-me')
-    .setDescription(
-      'Mark a task as assigned and define the name of the user that is assigned in the thread'
-    ),
+    .setDescription(translateLanguage('tasksThread.taskDescription')),
   async execute(interaction) {
     try {
       const { channel, client, user } = interaction;

--- a/src/index.js
+++ b/src/index.js
@@ -75,6 +75,7 @@ const client = new Client({
     GatewayIntentBits.Guilds,
     GatewayIntentBits.GuildMessages,
     GatewayIntentBits.MessageContent,
+    GatewayIntentBits.GuildMembers,
   ],
 });
 client.commands = new Collection();

--- a/src/languages/translations/en.json
+++ b/src/languages/translations/en.json
@@ -119,7 +119,6 @@
     "boostedPoints": "Boosted Points",
     "totalPoints": "Total Points"
   },
-
   "checkReview": {
     "description": "Check for PRs that need code reviews",
     "channelOption": "Select the channel to check for PRs",
@@ -129,5 +128,10 @@
     "remindersSent": "Sent reminders for {count} PR(s) requiring review in channel {{channelName}}.",
     "threadNotReviewed": "The thread {{threadName}} has not been reviewed:\n {{threadUrl}}",
     "error": "An error occurred while checking for PRs. Please try again later."
+  },
+  "tasksThread": {
+    "taskAssigned": "This task has been assigned to this user already",
+    "taskAssignedTo": "Task assigned to {{newUserId}}!",
+    "reassignedTaskTo": "{{originalUserAssigned}}, {{newUserAssigned}} has reassigned this task to him"
   }
 }

--- a/src/languages/translations/en.json
+++ b/src/languages/translations/en.json
@@ -146,6 +146,7 @@
     "qaChannelNotFound": "Sorry, the channel: #{{channelName}} for QA requests was not found!"
   },
   "tasksThread": {
+    "taskDescription": "Mark a task as assigned and define the name of the user that is assigned in the thread",
     "taskAssigned": "This task has been assigned to this user already",
     "taskAssignedTo": "Task assigned to {{newUserId}}!",
     "reassignedTaskTo": "{{originalUserAssigned}}, {{newUserAssigned}} has reassigned this task to him"

--- a/src/languages/translations/es.json
+++ b/src/languages/translations/es.json
@@ -146,9 +146,10 @@
     "qaRequest": "El rol {{role}} ha sido mencionado y se ha solicitado una revisión. [Ver mensaje]({{link}}).\n> {{content}}.\n\nPor favor, crea un hilo en este mensaje para enviar tu informe.",
     "qaChannelNotFound": "Lo siento, el canal: #{{channelName}} para solicitudes de QA no fue encontrado!"
   },
-  "task_assigned": "Esta tarea ha sido asignada a este usuario ya",
-  "taskAssignedTo": "Tarea asignada a {{newUserID}}!",
   "tasksThread": {
+    "taskDescription": "Marca una tarea como asignada y define el nombre del usuario asignado en el hilo",
+    "taskAssigned": "Esta tarea ha sido asignada a este usuario ya",
+    "taskAssignedTo": "Tarea asignada a {{newUserID}}!",
     "reassignedTaskTo": "{{originalUserAssigned}}, {{newUserAssigned}} se ha reasignado esta tarea"
   }
 }

--- a/src/languages/translations/es.json
+++ b/src/languages/translations/es.json
@@ -120,7 +120,6 @@
     "boostedPoints": "Puntos potenciados",
     "totalPoints": "Total de puntos"
   },
-
   "checkReview": {
     "description": "Revisar los PR que necesitan revisiones de código",
     "channelOption": "Selecciona el canal para verificar los PR",
@@ -130,5 +129,10 @@
     "remindersSent": "Se enviaron recordatorios para {count} PR(s) que requieren revisión en el canal {{channelName}}.",
     "threadNotReviewed": "El hilo {{threadName}} no ha sido revisado:\n {{threadUrl}}",
     "error": "Ocurrió un error al verificar los PR. Por favor, intenta nuevamente más tarde."
+  },
+  "task_assigned": "Esta tarea ha sido asignada a este usuario ya",
+  "taskAssignedTo": "Tarea asignada a {{newUserID}}!",
+  "tasksThread": {
+    "reassignedTaskTo": "{{originalUserAssigned}}, {{newUserAssigned}} se ha reasignado esta tarea"
   }
 }


### PR DESCRIPTION
### Description
This PR introduces the following enhancements to the `/assign-me` command:

- "Assigned" Status: Adds a new status to the task when it is assigned to a user.
- Title Update: Updates the thread title to include the name of the assigned user and an "Assigned" icon (e.g., ⚔).

Fixes:
 - #96  

#### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] Doesn't break the current code.
- [x] Passes linters and tests, also is building.
- [x] Doesn't have spelling or grammatical problems.
- [x] Doesn't have unnecessary comments or debugging code.
- [x] The bot is listening to events to check if any are about to end.
- [x] Change title thread and add icon and user name to indicate thread assignment.

### How to Test It:
- Assigning a task to a user for the first time.
- Reassigning a task to the same user.
- Reassigning a task to a different user.

### Screenshots

>![image](https://github.com/user-attachments/assets/48060b04-52ab-4240-948a-97cd334f1d02)
