### PR TITLE
fix: rename event config

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -13,7 +13,7 @@ const DISCORD_SERVER = {
 };
 
 const LISTEN_NEW_EVENTS = {
-  report_channel: process.env.ANNOUNCEMENTS_CHANNEL_ID,
+  report_channel: process.env.DISCORD_ANNOUNCEMENTS_CHANNEL_ID,
 };
 
 const MAPPED_STATUS_COMMANDS = {


### PR DESCRIPTION
Change the name of the variable so that it is the same and there would be no error like this call in Heroku