### PR TITLE
Feat/iss 114/report bot errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ DISCORD_LANGUAGE = en # The language of the bot (en, es) default en
 TASK_COMPLETED_TAG_ID = 1203085046769262592 # ID for task completed tag
 ADD_POINT_TAG_ID = 1258801833191669802 # ID for task completed tag.
 ADD_BOOSTED_POINT_TAG_ID = 1263873487953592381 # ID for the tag that adds boosted points
+ERROR_CHANNEL_ID= # The channel ID where the bot will send error messages
 DISCORD_QA_ROLE_ID=1140734540139204800
 DISCORD_QA_CHANNEL_ID=qa-request
 DISCORD_ANNOUNCEMENTS_CHANNEL_ID=1331274827410964571

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "prettier": "3.3.3"
   },
   "bugs": {
-   "url": "https://github.com/TeamNovaSoft/novabot/issues/new/choose"
-}
+    "url": "https://github.com/TeamNovaSoft/novabot/issues/new/choose"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
     "husky": "^9.1.7",
     "lint-staged": "^15.2.10",
     "prettier": "3.3.3"
-  }
+  },
+  "bugs": {
+   "url": "https://github.com/TeamNovaSoft/novabot/issues/new/choose"
+}
 }

--- a/src/commands/utility/assignMeTaskThread.js
+++ b/src/commands/utility/assignMeTaskThread.js
@@ -79,11 +79,7 @@ module.exports = {
       });
     } catch (error) {
       console.error(error);
-      await sendErrorToChannel(
-        interaction,
-        translateLanguage('sendChannelError.error'),
-        error
-      );
+      await sendErrorToChannel(interaction, error);
       await interaction.editReply(translateLanguage('changeStatus.error'));
     }
   },

--- a/src/commands/utility/assignMeTaskThread.js
+++ b/src/commands/utility/assignMeTaskThread.js
@@ -82,8 +82,7 @@ module.exports = {
       await sendErrorToChannel(
         interaction,
         translateLanguage('sendChannelError.error'),
-        error,
-        { user: interaction.user.tag }
+        error
       );
       await interaction.editReply(translateLanguage('changeStatus.error'));
     }

--- a/src/commands/utility/assignMeTaskThread.js
+++ b/src/commands/utility/assignMeTaskThread.js
@@ -81,7 +81,7 @@ module.exports = {
       console.error(error);
       await sendErrorToChannel(
         interaction,
-        translateLanguage('sendChannelError.error'), // Título genérico, el nombre del comando se obtiene de interaction.commandName
+        translateLanguage('sendChannelError.error'),
         error,
         { user: interaction.user.tag }
       );

--- a/src/commands/utility/assignMeTaskThread.js
+++ b/src/commands/utility/assignMeTaskThread.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder } = require('discord.js');
 const { DISCORD_SERVER } = require('../../config');
 const { translateLanguage } = require('../../languages/index');
+const { sendErrorToChannel } = require('../../utils/send-error');
 
 const ASSIGN_EMOJI = '⚔';
 const ASSIGNED_PATTERN = new RegExp(`\\|${ASSIGN_EMOJI} @[\\w-]+\\|`);
@@ -78,6 +79,12 @@ module.exports = {
       });
     } catch (error) {
       console.error(error);
+      await sendErrorToChannel(
+        interaction,
+        translateLanguage('sendChannelError.error'), // Título genérico, el nombre del comando se obtiene de interaction.commandName
+        error,
+        { user: interaction.user.tag }
+      );
       await interaction.editReply(translateLanguage('changeStatus.error'));
     }
   },

--- a/src/commands/utility/changeStatus.js
+++ b/src/commands/utility/changeStatus.js
@@ -74,11 +74,7 @@ module.exports = {
       );
     } catch (error) {
       console.error(error);
-      await sendErrorToChannel(
-        interaction,
-        translateLanguage('sendChannelError.error'),
-        error
-      );
+      await sendErrorToChannel(interaction, error);
       await interaction.editReply(translateLanguage('changeStatus.error'));
     }
   },

--- a/src/commands/utility/changeStatus.js
+++ b/src/commands/utility/changeStatus.js
@@ -77,8 +77,7 @@ module.exports = {
       await sendErrorToChannel(
         interaction,
         translateLanguage('sendChannelError.error'),
-        error,
-        { user: interaction.user.tag }
+        error
       );
       await interaction.editReply(translateLanguage('changeStatus.error'));
     }

--- a/src/commands/utility/changeStatus.js
+++ b/src/commands/utility/changeStatus.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder } = require('discord.js');
 const { MAPPED_STATUS_COMMANDS } = require('../../config');
 const { translateLanguage } = require('../../languages/index');
+const { sendErrorToChannel } = require('../../utils/send-error');
 
 const COMMAND_KEYS = Object.keys(MAPPED_STATUS_COMMANDS);
 
@@ -73,6 +74,12 @@ module.exports = {
       );
     } catch (error) {
       console.error(error);
+      await sendErrorToChannel(
+        interaction,
+        translateLanguage('sendChannelError.error'),
+        error,
+        { user: interaction.user.tag }
+      );
       await interaction.editReply(translateLanguage('changeStatus.error'));
     }
   },

--- a/src/commands/utility/convert-time.js
+++ b/src/commands/utility/convert-time.js
@@ -65,11 +65,7 @@ module.exports = {
       );
     } catch (error) {
       console.error(error);
-      await sendErrorToChannel(
-        interaction,
-        translateLanguage('sendChannelError.error'),
-        error
-      );
+      await sendErrorToChannel(interaction, error);
       await interaction.reply(translateLanguage('convertTime.error'));
     }
   },

--- a/src/commands/utility/convert-time.js
+++ b/src/commands/utility/convert-time.js
@@ -68,8 +68,7 @@ module.exports = {
       await sendErrorToChannel(
         interaction,
         translateLanguage('sendChannelError.error'),
-        error,
-        { user: interaction.user.tag }
+        error
       );
       await interaction.reply(translateLanguage('convertTime.error'));
     }

--- a/src/commands/utility/convert-time.js
+++ b/src/commands/utility/convert-time.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder } = require('discord.js');
 const moment = require('moment-timezone');
 const { TIME_ZONES } = require('../../config');
 const { translateLanguage } = require('../../languages/index');
+const { sendErrorToChannel } = require('../../utils/send-error');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -64,6 +65,12 @@ module.exports = {
       );
     } catch (error) {
       console.error(error);
+      await sendErrorToChannel(
+        interaction,
+        translateLanguage('sendChannelError.error'),
+        error,
+        { user: interaction.user.tag }
+      );
       await interaction.reply(translateLanguage('convertTime.error'));
     }
   },

--- a/src/commands/utility/my-points.js
+++ b/src/commands/utility/my-points.js
@@ -128,11 +128,7 @@ module.exports = {
       });
     } catch (error) {
       console.error(`Error in my-points command: ${error}`);
-      await sendErrorToChannel(
-        interaction,
-        translateLanguage('sendChannelError.error'),
-        error
-      );
+      await sendErrorToChannel(interaction, error);
       await interaction.editReply({
         content: translateLanguage(
           'myPoints.errorFetching',

--- a/src/commands/utility/my-points.js
+++ b/src/commands/utility/my-points.js
@@ -131,8 +131,7 @@ module.exports = {
       await sendErrorToChannel(
         interaction,
         translateLanguage('sendChannelError.error'),
-        error,
-        { user: interaction.user.tag }
+        error
       );
       await interaction.editReply({
         content: translateLanguage(

--- a/src/commands/utility/my-points.js
+++ b/src/commands/utility/my-points.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder } = require('discord.js');
 const { translateLanguage } = require('../../languages/index');
 const { VOTE_POINTS } = require('../../config');
+const { sendErrorToChannel } = require('../../utils/send-error');
 
 const tagIds = VOTE_POINTS.TAG_IDS;
 
@@ -127,6 +128,12 @@ module.exports = {
       });
     } catch (error) {
       console.error(`Error in my-points command: ${error}`);
+      await sendErrorToChannel(
+        interaction,
+        translateLanguage('sendChannelError.error'),
+        error,
+        { user: interaction.user.tag }
+      );
       await interaction.editReply({
         content: translateLanguage(
           'myPoints.errorFetching',

--- a/src/commands/utility/requestPoint.js
+++ b/src/commands/utility/requestPoint.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder } = require('discord.js');
 const { REQUEST_POINT } = require('../../config');
 const { translateLanguage } = require('../../languages/index');
+const { sendErrorToChannel } = require('../../utils/send-error');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -54,6 +55,12 @@ module.exports = {
       });
     } catch (error) {
       console.error('Error executing request-point command:', error);
+      await sendErrorToChannel(
+        interaction,
+        translateLanguage('sendChannelError.error'),
+        error,
+        { user: interaction.user.tag }
+      );
 
       await interaction.reply({
         content: translateLanguage('requestPoint.error'),

--- a/src/commands/utility/requestPoint.js
+++ b/src/commands/utility/requestPoint.js
@@ -58,8 +58,7 @@ module.exports = {
       await sendErrorToChannel(
         interaction,
         translateLanguage('sendChannelError.error'),
-        error,
-        { user: interaction.user.tag }
+        error
       );
 
       await interaction.reply({

--- a/src/commands/utility/requestPoint.js
+++ b/src/commands/utility/requestPoint.js
@@ -55,12 +55,7 @@ module.exports = {
       });
     } catch (error) {
       console.error('Error executing request-point command:', error);
-      await sendErrorToChannel(
-        interaction,
-        translateLanguage('sendChannelError.error'),
-        error
-      );
-
+      await sendErrorToChannel(interaction, error);
       await interaction.reply({
         content: translateLanguage('requestPoint.error'),
         ephemeral: true,

--- a/src/commands/utility/search-code-review.js
+++ b/src/commands/utility/search-code-review.js
@@ -74,8 +74,7 @@ module.exports = {
       await sendErrorToChannel(
         interaction,
         translateLanguage('sendChannelError.error'),
-        error,
-        { user: interaction.user.tag }
+        error
       );
 
       await interaction.reply({

--- a/src/commands/utility/search-code-review.js
+++ b/src/commands/utility/search-code-review.js
@@ -4,6 +4,7 @@ const {
   getMappedStatusText,
   STATUS_KEY,
 } = require('../../cron/schedule-code-review');
+const { sendErrorToChannel } = require('../../utils/send-error');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -70,6 +71,13 @@ module.exports = {
       }
     } catch (error) {
       console.error(`Error in check-review command: ${error}`);
+      await sendErrorToChannel(
+        interaction,
+        translateLanguage('sendChannelError.error'),
+        error,
+        { user: interaction.user.tag }
+      );
+
       await interaction.reply({
         content: translateLanguage('checkReview.error'),
         ephemeral: true,

--- a/src/commands/utility/search-code-review.js
+++ b/src/commands/utility/search-code-review.js
@@ -71,12 +71,7 @@ module.exports = {
       }
     } catch (error) {
       console.error(`Error in check-review command: ${error}`);
-      await sendErrorToChannel(
-        interaction,
-        translateLanguage('sendChannelError.error'),
-        error
-      );
-
+      await sendErrorToChannel(interaction, error);
       await interaction.reply({
         content: translateLanguage('checkReview.error'),
         ephemeral: true,

--- a/src/commands/utility/search-my-points.js
+++ b/src/commands/utility/search-my-points.js
@@ -82,8 +82,7 @@ module.exports = {
       await sendErrorToChannel(
         interaction,
         translateLanguage('sendChannelError.error'),
-        error,
-        { user: interaction.user.tag }
+        error
       );
     }
   },

--- a/src/commands/utility/search-my-points.js
+++ b/src/commands/utility/search-my-points.js
@@ -79,11 +79,7 @@ module.exports = {
         ephemeral: true,
       });
     } catch (error) {
-      await sendErrorToChannel(
-        interaction,
-        translateLanguage('sendChannelError.error'),
-        error
-      );
+      await sendErrorToChannel(interaction, error);
     }
   },
 };

--- a/src/commands/utility/search-my-points.js
+++ b/src/commands/utility/search-my-points.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder } = require('discord.js');
 const { VOTE_POINTS } = require('../../config');
 const { translateLanguage } = require('../../languages/index');
+const { sendErrorToChannel } = require('../../utils/send-error');
 
 const tagIds = VOTE_POINTS.TAG_IDS;
 
@@ -34,47 +35,56 @@ module.exports = {
     ),
 
   async execute(interaction) {
-    const currentDate = new Date();
-    const year =
-      interaction.options.getInteger('year') || currentDate.getFullYear();
-    const month =
-      interaction.options.getInteger('month') || currentDate.getMonth() + 1;
-    const user = interaction.options.getUser('user') || interaction.user;
+    try {
+      const currentDate = new Date();
+      const year =
+        interaction.options.getInteger('year') || currentDate.getFullYear();
+      const month =
+        interaction.options.getInteger('month') || currentDate.getMonth() + 1;
+      const user = interaction.options.getUser('user') || interaction.user;
 
-    const channelsInput = interaction.options.getString('channels');
-    const channels = channelsInput
-      ? channelsInput.split(',').map((channel) => channel.trim())
-      : [];
+      const channelsInput = interaction.options.getString('channels');
+      const channels = channelsInput
+        ? channelsInput.split(',').map((channel) => channel.trim())
+        : [];
 
-    const targetStartDate = new Date(year, month - 1, 0);
-    const targetEndDate = new Date(year, month, 1);
+      const targetStartDate = new Date(year, month - 1, 0);
+      const targetEndDate = new Date(year, month, 1);
 
-    const startDateStr = `${targetStartDate.getFullYear()}-${String(
-      targetStartDate.getMonth() + 1
-    ).padStart(2, '0')}-${String(targetStartDate.getDate())}`;
-    const endDateStr = `${targetEndDate.getFullYear()}-${String(
-      targetEndDate.getMonth() + 1
-    ).padStart(2, '0')}-01`;
+      const startDateStr = `${targetStartDate.getFullYear()}-${String(
+        targetStartDate.getMonth() + 1
+      ).padStart(2, '0')}-${String(targetStartDate.getDate())}`;
+      const endDateStr = `${targetEndDate.getFullYear()}-${String(
+        targetEndDate.getMonth() + 1
+      ).padStart(2, '0')}-01`;
 
-    const escapedUserId = `<@${user.id}>`;
+      const escapedUserId = `<@${user.id}>`;
 
-    const channelQueryParts = channels.length
-      ? channels.map((channel) => `in:${channel}`).join(' ')
-      : '';
+      const channelQueryParts = channels.length
+        ? channels.map((channel) => `in:${channel}`).join(' ')
+        : '';
 
-    const openedPRs = `before: ${endDateStr} after: ${startDateStr} ${channelQueryParts} Author: ${escapedUserId}`;
-    const taskCompletedQuery = `before: ${endDateStr} after: ${startDateStr} ${channelQueryParts} <@&${tagIds.taskCompletedTagId}> ${escapedUserId}`;
-    const addPointQuery = `before: ${endDateStr} after: ${startDateStr} ${channelQueryParts} <@&${tagIds.addPointTagId}> ${escapedUserId}`;
-    const boostedPointQuery = `before: ${endDateStr} after: ${startDateStr} ${channelQueryParts} <@&${tagIds.boostedPointTagId}> ${escapedUserId}`;
+      const openedPRs = `before: ${endDateStr} after: ${startDateStr} ${channelQueryParts} Author: ${escapedUserId}`;
+      const taskCompletedQuery = `before: ${endDateStr} after: ${startDateStr} ${channelQueryParts} <@&${tagIds.taskCompletedTagId}> ${escapedUserId}`;
+      const addPointQuery = `before: ${endDateStr} after: ${startDateStr} ${channelQueryParts} <@&${tagIds.addPointTagId}> ${escapedUserId}`;
+      const boostedPointQuery = `before: ${endDateStr} after: ${startDateStr} ${channelQueryParts} <@&${tagIds.boostedPointTagId}> ${escapedUserId}`;
 
-    await interaction.reply({
-      content: translateLanguage('searchMyPoints.reply', {
-        openedPRs,
-        taskCompletedQuery,
-        addPointQuery,
-        boostedPointQuery,
-      }),
-      ephemeral: true,
-    });
+      await interaction.reply({
+        content: translateLanguage('searchMyPoints.reply', {
+          openedPRs,
+          taskCompletedQuery,
+          addPointQuery,
+          boostedPointQuery,
+        }),
+        ephemeral: true,
+      });
+    } catch (error) {
+      await sendErrorToChannel(
+        interaction,
+        translateLanguage('sendChannelError.error'),
+        error,
+        { user: interaction.user.tag }
+      );
+    }
   },
 };

--- a/src/commands/utility/send-message.js
+++ b/src/commands/utility/send-message.js
@@ -26,11 +26,7 @@ module.exports = {
         await interaction.showModal(modal);
       }
     } catch (error) {
-      await sendErrorToChannel(
-        interaction,
-        translateLanguage('sendChannelError.error'),
-        error
-      );
+      await sendErrorToChannel(interaction, error);
     }
   },
 };

--- a/src/commands/utility/send-message.js
+++ b/src/commands/utility/send-message.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder } = require('discord.js');
 const { createSendMessageModal } = require('../../modals/send-message-modal');
 const { translateLanguage } = require('../../languages/index');
+const { sendErrorToChannel } = require('../../utils/send-error');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -12,16 +13,25 @@ module.exports = {
         .setDescription(translateLanguage('sendMessage.channelOption'))
     ),
   async execute(interaction) {
-    const channel = interaction.options.getChannel('channel');
-    const channelId = channel?.id;
-    const user = interaction.user;
+    try {
+      const channel = interaction.options.getChannel('channel');
+      const channelId = channel?.id;
+      const user = interaction.user;
 
-    if (channelId) {
-      const modal = createSendMessageModal(channelId, user);
-      await interaction.showModal(modal);
-    } else {
-      const modal = createSendMessageModal(interaction.channelId, user);
-      await interaction.showModal(modal);
+      if (channelId) {
+        const modal = createSendMessageModal(channelId, user);
+        await interaction.showModal(modal);
+      } else {
+        const modal = createSendMessageModal(interaction.channelId, user);
+        await interaction.showModal(modal);
+      }
+    } catch (error) {
+      await sendErrorToChannel(
+        interaction,
+        translateLanguage('sendChannelError.error'),
+        error,
+        { user: interaction.user.tag }
+      );
     }
   },
 };

--- a/src/commands/utility/send-message.js
+++ b/src/commands/utility/send-message.js
@@ -29,8 +29,7 @@ module.exports = {
       await sendErrorToChannel(
         interaction,
         translateLanguage('sendChannelError.error'),
-        error,
-        { user: interaction.user.tag }
+        error
       );
     }
   },

--- a/src/cron/schedule-code-review.js
+++ b/src/cron/schedule-code-review.js
@@ -93,8 +93,7 @@ const checkThreadsForReview = async (client, statusText) => {
     sendErrorToChannel(
       client,
       translateLanguage('sendChannelError.error'),
-      error,
-      { command: scheduleReviewCheck.name, user: client.user.tag }
+      error
     );
   }
 };

--- a/src/cron/schedule-code-review.js
+++ b/src/cron/schedule-code-review.js
@@ -132,8 +132,7 @@ const scheduleReviewCheck = (client) => {
     sendErrorToChannel(
       client,
       translateLanguage('sendChannelError.error'),
-      error,
-      { command: scheduleReviewCheck.name, user: client.user.tag }
+      error
     );
   }
 };

--- a/src/cron/schedule-code-review.js
+++ b/src/cron/schedule-code-review.js
@@ -2,6 +2,8 @@ const { CronJob } = require('cron');
 const { ChannelType } = require('discord.js');
 const { translateLanguage } = require('../languages/index');
 const saveErrorLog = require('../utils/log-error');
+const { sendErrorToChannel } = require('../utils/send-error');
+
 const {
   MAPPED_STATUS_COMMANDS,
   DISCORD_SERVER,
@@ -88,6 +90,12 @@ const checkThreadsForReview = async (client, statusText) => {
     }
   } catch (error) {
     saveErrorLog(error);
+    sendErrorToChannel(
+      client,
+      translateLanguage('sendChannelError.error'),
+      error,
+      { command: scheduleReviewCheck.name, user: client.user.tag }
+    );
   }
 };
 
@@ -121,6 +129,12 @@ const scheduleReviewCheck = (client) => {
     );
   } catch (error) {
     console.error('Failed to create CronJob:', error.message);
+    sendErrorToChannel(
+      client,
+      translateLanguage('sendChannelError.error'),
+      error,
+      { command: scheduleReviewCheck.name, user: client.user.tag }
+    );
   }
 };
 

--- a/src/cron/schedule-code-review.js
+++ b/src/cron/schedule-code-review.js
@@ -90,11 +90,7 @@ const checkThreadsForReview = async (client, statusText) => {
     }
   } catch (error) {
     saveErrorLog(error);
-    sendErrorToChannel(
-      client,
-      translateLanguage('sendChannelError.error'),
-      error
-    );
+    sendErrorToChannel(client, error);
   }
 };
 
@@ -128,11 +124,7 @@ const scheduleReviewCheck = (client) => {
     );
   } catch (error) {
     console.error('Failed to create CronJob:', error.message);
-    sendErrorToChannel(
-      client,
-      translateLanguage('sendChannelError.error'),
-      error
-    );
+    sendErrorToChannel(client, error);
   }
 };
 

--- a/src/cron/schedule-event-reminder.js
+++ b/src/cron/schedule-event-reminder.js
@@ -66,10 +66,13 @@ const scheduleEventReminder = ({ client, event, channelId, timeZone }) => {
           `Error sending event reminder in channel - '${channelId}': ${error.message}`
         );
         sendErrorToChannel(
-          client,
+          {
+            client,
+            commandName: scheduleEventReminder.name,
+            user: client.user,
+          },
           translateLanguage('sendChannelError.error'),
-          error,
-          { command: scheduleEventReminder.name, user: client.user.tag }
+          error
         );
       }
     },

--- a/src/cron/schedule-event-reminder.js
+++ b/src/cron/schedule-event-reminder.js
@@ -66,11 +66,7 @@ const scheduleEventReminder = ({ client, event, channelId, timeZone }) => {
           `Error sending event reminder in channel - '${channelId}': ${error.message}`
         );
         sendErrorToChannel(
-          {
-            client,
-            commandName: scheduleEventReminder.name,
-            user: client.user,
-          },
+          client,
           translateLanguage('sendChannelError.error'),
           error
         );

--- a/src/cron/schedule-event-reminder.js
+++ b/src/cron/schedule-event-reminder.js
@@ -65,11 +65,7 @@ const scheduleEventReminder = ({ client, event, channelId, timeZone }) => {
         saveErrorLog(
           `Error sending event reminder in channel - '${channelId}': ${error.message}`
         );
-        sendErrorToChannel(
-          client,
-          translateLanguage('sendChannelError.error'),
-          error
-        );
+        sendErrorToChannel(client, error);
       }
     },
     null,

--- a/src/cron/schedule-event-reminder.js
+++ b/src/cron/schedule-event-reminder.js
@@ -4,6 +4,7 @@ const { translateLanguage } = require('../languages/index');
 const dateToCronExpression = require('../utils/date-to-cron-expression');
 const { SCHEDULE_MESSAGES } = require('../config');
 const saveErrorLog = require('../utils/log-error');
+const { sendErrorToChannel } = require('../utils/send-error');
 
 const hoursInMilliseconds = 60 * 60 * 1000;
 const dayInMilliseconds = 24 * hoursInMilliseconds;
@@ -63,6 +64,12 @@ const scheduleEventReminder = ({ client, event, channelId, timeZone }) => {
       } catch (error) {
         saveErrorLog(
           `Error sending event reminder in channel - '${channelId}': ${error.message}`
+        );
+        sendErrorToChannel(
+          client,
+          translateLanguage('sendChannelError.error'),
+          error,
+          { command: scheduleEventReminder.name, user: client.user.tag }
         );
       }
     },

--- a/src/cron/schedule-gemini.js
+++ b/src/cron/schedule-gemini.js
@@ -32,10 +32,13 @@ const generateIaContent = async ({ client, channel, prompts }) => {
   } catch (error) {
     console.error(error);
     sendErrorToChannel(
-      client,
+      {
+        client,
+        commandName: generateIaContent.name,
+        user: client.user,
+      },
       translateLanguage('sendChannelError.error'),
-      error,
-      { command: generateIaContent.name, user: client.user.tag }
+      error
     );
     return null;
   }

--- a/src/cron/schedule-gemini.js
+++ b/src/cron/schedule-gemini.js
@@ -1,7 +1,6 @@
 const { CronJob } = require('cron');
 const { GoogleGenerativeAI } = require('@google/generative-ai');
 const { GEMINI_INTEGRATION, SCHEDULE_MESSAGES } = require('../config');
-const { translateLanguage } = require('../languages/index');
 const { sendErrorToChannel } = require('../utils/send-error');
 const genAI = new GoogleGenerativeAI(GEMINI_INTEGRATION.geminiSecret);
 
@@ -31,11 +30,7 @@ const generateIaContent = async ({ client, channel, prompts }) => {
     currentChannel.send(result.response.text());
   } catch (error) {
     console.error(error);
-    sendErrorToChannel(
-      client,
-      translateLanguage('sendChannelError.error'),
-      error
-    );
+    sendErrorToChannel(client, error);
     return null;
   }
 };

--- a/src/cron/schedule-gemini.js
+++ b/src/cron/schedule-gemini.js
@@ -32,11 +32,7 @@ const generateIaContent = async ({ client, channel, prompts }) => {
   } catch (error) {
     console.error(error);
     sendErrorToChannel(
-      {
-        client,
-        commandName: generateIaContent.name,
-        user: client.user,
-      },
+      client,
       translateLanguage('sendChannelError.error'),
       error
     );

--- a/src/cron/schedule-gemini.js
+++ b/src/cron/schedule-gemini.js
@@ -1,7 +1,8 @@
 const { CronJob } = require('cron');
 const { GoogleGenerativeAI } = require('@google/generative-ai');
 const { GEMINI_INTEGRATION, SCHEDULE_MESSAGES } = require('../config');
-
+const { translateLanguage } = require('../languages/index');
+const { sendErrorToChannel } = require('../utils/send-error');
 const genAI = new GoogleGenerativeAI(GEMINI_INTEGRATION.geminiSecret);
 
 /**
@@ -30,6 +31,12 @@ const generateIaContent = async ({ client, channel, prompts }) => {
     currentChannel.send(result.response.text());
   } catch (error) {
     console.error(error);
+    sendErrorToChannel(
+      client,
+      translateLanguage('sendChannelError.error'),
+      error,
+      { command: generateIaContent.name, user: client.user.tag }
+    );
     return null;
   }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ const saveErrorLog = require('./utils/log-error');
 const convertCronToText = require('./utils/cron-to-text-parser');
 const { processMarkdownFiles } = require('./cron/utils/read-markdown-messages');
 const { scheduleReviewCheck } = require('./cron/schedule-code-review');
-const { registerGlobalErrorHandlers } = require('./utils/send-error');
+const { sendErrorToChannel } = require('./utils/send-error');
 
 async function startClientBot(client) {
   client.commands = new Collection();
@@ -68,7 +68,7 @@ async function startClientBot(client) {
 
 function handleCriticalError(error) {
   saveErrorLog(error);
-  registerGlobalErrorHandlers(client);
+  sendErrorToChannel(client, error);
 }
 
 const token = DISCORD_SERVER.discordToken;
@@ -83,15 +83,13 @@ const client = new Client({
 });
 client.commands = new Collection();
 
-registerGlobalErrorHandlers(client);
-
 process.on('uncaughtException', (error) => {
-  handleCriticalError(error, client);
+  handleCriticalError(error);
 });
 
 process.on('unhandledRejection', (reason, promise) => {
   console.error('Unhandled Rejection at:', promise);
-  handleCriticalError(reason, client);
+  handleCriticalError(reason);
 });
 
 startClientBot(client);

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ const saveErrorLog = require('./utils/log-error');
 const convertCronToText = require('./utils/cron-to-text-parser');
 const { processMarkdownFiles } = require('./cron/utils/read-markdown-messages');
 const { scheduleReviewCheck } = require('./cron/schedule-code-review');
+const { registerGlobalErrorHandlers } = require('./utils/send-error');
 
 async function startClientBot(client) {
   client.commands = new Collection();
@@ -83,11 +84,13 @@ client.commands = new Collection();
 
 process.on('uncaughtException', (error) => {
   handleCriticalError(error);
+  registerGlobalErrorHandlers(client);
 });
 
 process.on('unhandledRejection', (reason, promise) => {
   console.error('Unhandled Rejection at:', promise);
   handleCriticalError(reason);
+  registerGlobalErrorHandlers(client);
 });
 
 startClientBot(client);

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,6 @@ const {
 } = require('./cron/schedule-google-calendar');
 const cron = require('cron');
 const { scheduleIaContentLogging } = require('../src/cron/schedule-gemini');
-const saveErrorLog = require('./utils/log-error');
 const convertCronToText = require('./utils/cron-to-text-parser');
 const { processMarkdownFiles } = require('./cron/utils/read-markdown-messages');
 const { scheduleReviewCheck } = require('./cron/schedule-code-review');
@@ -66,10 +65,6 @@ async function startClientBot(client) {
   }
 }
 
-function handleCriticalError(error) {
-  saveErrorLog(error);
-}
-
 const token = DISCORD_SERVER.discordToken;
 const client = new Client({
   intents: [
@@ -82,15 +77,6 @@ const client = new Client({
 });
 client.commands = new Collection();
 
-process.on('uncaughtException', (error) => {
-  handleCriticalError(error);
-  registerGlobalErrorHandlers(client);
-});
-
-process.on('unhandledRejection', (reason, promise) => {
-  console.error('Unhandled Rejection at:', promise);
-  handleCriticalError(reason);
-  registerGlobalErrorHandlers(client);
-});
+registerGlobalErrorHandlers(client);
 
 startClientBot(client);

--- a/src/languages/translations/en.json
+++ b/src/languages/translations/en.json
@@ -152,7 +152,8 @@
     "reassignedTaskTo": "{{originalUserAssigned}}, {{newUserAssigned}} has reassigned this task to him"
   },
   "sendChannelError": {
-    "error": "An error occurred  in the command",
+    "error": "An error occurred you can pass this location to the technical service",
+    "couldNotSendToUser": "Could not send an error message to the user.",
     "unknownCommand": "unknown command",
     "unknownUser": "unknown user",
     "unknownFunction": "unknown function",

--- a/src/languages/translations/en.json
+++ b/src/languages/translations/en.json
@@ -150,5 +150,17 @@
     "taskAssigned": "This task has been assigned to this user already",
     "taskAssignedTo": "Task assigned to {{newUserId}}!",
     "reassignedTaskTo": "{{originalUserAssigned}}, {{newUserAssigned}} has reassigned this task to him"
+  },
+  "sendChannelError": {
+    "error": "An error occurred  in the command",
+    "unknownCommand": "unknown command",
+    "unknownUser": "unknown user",
+    "unknownFunction": "unknown function",
+    "channelNotFound": "The error channel does not exist or is not a text channel.",
+    "couldNotSend": "Could not send the error message:",
+    "commandLabel": "Command/Function:",
+    "userLabel": "User:",
+    "channelLabel": "Channel:",
+    "errorLabel": "Error:"
   }
 }

--- a/src/languages/translations/en.json
+++ b/src/languages/translations/en.json
@@ -162,6 +162,12 @@
     "commandLabel": "Command/Function:",
     "userLabel": "User:",
     "channelLabel": "Channel:",
+    "reportIssue": "Report this issue",
+    "clickHere": "Click here",
     "errorLabel": "Error:"
+  },
+  "githubIssue": {
+    "warning": "Bug reporting URL not found in package.json.",
+    "error": "Could not read package.json"
   }
 }

--- a/src/languages/translations/es.json
+++ b/src/languages/translations/es.json
@@ -151,5 +151,16 @@
     "taskAssigned": "Esta tarea ha sido asignada a este usuario ya",
     "taskAssignedTo": "Tarea asignada a {{newUserID}}!",
     "reassignedTaskTo": "{{originalUserAssigned}}, {{newUserAssigned}} se ha reasignado esta tarea"
+  },
+  "sendChannelError": {
+    "unknownCommand": "comando desconocido",
+    "unknownUser": "usuario desconocido",
+    "unknownFunction": "función desconocida",
+    "channelNotFound": "El canal de errores no existe o no es un canal de texto.",
+    "couldNotSend": "No se pudo enviar el mensaje de error:",
+    "commandLabel": "Comando/Función:",
+    "userLabel": "Usuario:",
+    "channelLabel": "Canal:",
+    "errorLabel": "Error:"
   }
 }

--- a/src/languages/translations/es.json
+++ b/src/languages/translations/es.json
@@ -153,6 +153,7 @@
     "reassignedTaskTo": "{{originalUserAssigned}}, {{newUserAssigned}} se ha reasignado esta tarea"
   },
   "sendChannelError": {
+    "error": "Ocurrió un error puedes pasar esta ubicación al servicio técnico",
     "unknownCommand": "comando desconocido",
     "unknownUser": "usuario desconocido",
     "unknownFunction": "función desconocida",

--- a/src/languages/translations/es.json
+++ b/src/languages/translations/es.json
@@ -154,6 +154,7 @@
   },
   "sendChannelError": {
     "error": "Ocurrió un error puedes pasar esta ubicación al servicio técnico",
+    "noSePudoEnviarAlUsuario": "No se pudo enviar un mensaje de error al usuario.",
     "unknownCommand": "comando desconocido",
     "unknownUser": "usuario desconocido",
     "unknownFunction": "función desconocida",
@@ -161,7 +162,13 @@
     "couldNotSend": "No se pudo enviar el mensaje de error:",
     "commandLabel": "Comando/Función:",
     "userLabel": "Usuario:",
+    "reportIssue": "Reportar este problema",
+    "clickHere": "Haz clic aquí",
     "channelLabel": "Canal:",
     "errorLabel": "Error:"
+  },
+  "githubIssue": {
+    "warning": "URL de reporte de errores no encontrada en package.json.",
+    "error": "No se pudo leer package.json"
   }
 }

--- a/src/utils/githubIssue.js
+++ b/src/utils/githubIssue.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+const { translateLanguage } = require('../languages/index');
+
+function getGitHubIssueURL(errorMessage) {
+  try {
+    const packageJsonPath = path.join(__dirname, '../../package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+    const issueBaseUrl = packageJson.bugs?.url;
+
+    if (!issueBaseUrl) {
+      console.warn(translateLanguage('githubIssue.warning'));
+      return null;
+    }
+
+    const issueUrl = `${issueBaseUrl}?title=${encodeURIComponent('Error report')}&body=${encodeURIComponent(errorMessage)}`;
+
+    return issueUrl;
+  } catch (err) {
+    console.error(translateLanguage('githubIssue.error'), err);
+    return null;
+  }
+}
+
+module.exports = { getGitHubIssueURL };

--- a/src/utils/githubIssue.js
+++ b/src/utils/githubIssue.js
@@ -4,11 +4,10 @@ const { translateLanguage } = require('../languages/index');
 
 function getGitHubIssueURL(errorMessage) {
   try {
-    const packageJsonPath = path.join(__dirname, '../../package.json');
+    const packageJsonPath = path.join(process.cwd(), 'package.json');
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
 
-    const issueBaseUrl = packageJson.bugs?.url;
-
+    const issueBaseUrl = packageJson.bugs?.url.replace(/\/choose$/, '');
     if (!issueBaseUrl) {
       console.warn(translateLanguage('githubIssue.warning'));
       return null;

--- a/src/utils/send-error.js
+++ b/src/utils/send-error.js
@@ -1,0 +1,61 @@
+// utils/sendError.js
+require('dotenv').config();
+const { translateLanguage } = require('../languages/index');
+
+/**
+ * Sends an error message to the configured channel.
+ *
+ * @param {Interaction|Client} source - Can be the interaction object or directly the Discord client.
+ * @param {string} title - Title or header of the error.
+ * @param {Error} error - The Error object to report.
+ * @param {object} [additionalInfo={}] - Additional information (e.g., command, user, channel, etc.).
+ */
+async function sendErrorToChannel(source, title, error, additionalInfo = {}) {
+  let client, commandName, user;
+
+  // If "source" has interaction properties, it is assumed to be an interaction.
+  if (source && source.client && source.commandName) {
+    client = source.client;
+    commandName =
+      source.commandName ||
+      translateLanguage('sendChannelError.unknownCommand');
+    user = source.user
+      ? source.user.tag
+      : translateLanguage('sendChannelError.unknownUser');
+  } else {
+    // Otherwise, it is assumed that "source" is a client directly.
+    client = source;
+    commandName =
+      additionalInfo.command ||
+      translateLanguage('sendChannelError.unknownFunction');
+    user =
+      additionalInfo.user || translateLanguage('sendChannelError.unknownUser');
+  }
+
+  // Ensure additionalInfo has the command or function name.
+  additionalInfo.command = commandName;
+
+  const errorChannelID = process.env.ERROR_CHANNEL_ID;
+  const errorChannel = client.channels.cache.get(errorChannelID);
+
+  if (!errorChannel || !errorChannel.isTextBased()) {
+    console.error(translateLanguage('sendChannelError.channelNotFound'));
+    return;
+  }
+
+  // Format the error message
+  let message = `**${title}**\n`;
+  message += `**${translateLanguage('sendChannelError.commandLabel')}** ${commandName}\n`;
+  message += `**${translateLanguage('sendChannelError.userLabel')}** ${user}\n`;
+  if (additionalInfo.channel) {
+    message += `**${translateLanguage('sendChannelError.channelLabel')}** ${additionalInfo.channel}\n`;
+  }
+  message += `**${translateLanguage('sendChannelError.errorLabel')}** \`\`\`js\n${error.stack || error}\n\`\`\``;
+  try {
+    await errorChannel.send(message);
+  } catch (err) {
+    console.error(translateLanguage('sendChannelError.couldNotSend'), err);
+  }
+}
+
+module.exports = { sendErrorToChannel };

--- a/src/utils/send-error.js
+++ b/src/utils/send-error.js
@@ -28,8 +28,6 @@ async function sendErrorToChannel(source, error, additionalInfo = {}) {
   const errorChannel = client.channels.cache.get(errorChannelID);
 
   if (!errorChannel || !errorChannel.isTextBased()) {
-    console.error(translateLanguage('sendChannelError.channelNotFound'));
-
     if (interaction && interaction.replied === false) {
       try {
         await interaction.reply({
@@ -38,12 +36,8 @@ async function sendErrorToChannel(source, error, additionalInfo = {}) {
         });
       } catch (err) {
         console.error(
-          translateLanguage('sendChannelError.couldNotSendToUser'),
-          err
-        );
-
-        console.error(
-          `Failed to find error channel with ID: ${errorChannelID}`,
+          translateLanguage('sendChannelError.couldNotSendToUser \n'),
+          `Failed to find error channel with ID: ${errorChannelID}\n${err}`,
           err
         );
       }

--- a/src/utils/send-error.js
+++ b/src/utils/send-error.js
@@ -41,9 +41,13 @@ async function sendErrorToChannel(source, error, additionalInfo = {}) {
           translateLanguage('sendChannelError.couldNotSendToUser'),
           err
         );
+
+        console.error(
+          `Failed to find error channel with ID: ${errorChannelID}`,
+          err
+        );
       }
     }
-
     return;
   }
 

--- a/src/utils/send-error.js
+++ b/src/utils/send-error.js
@@ -84,14 +84,4 @@ async function sendErrorToChannel(source, error, additionalInfo = {}) {
   }
 }
 
-function registerGlobalErrorHandlers(client) {
-  process.on('uncaughtException', async (error) => {
-    await sendErrorToChannel(client, error);
-  });
-
-  process.on('unhandledRejection', async (reason) => {
-    await sendErrorToChannel(client, reason);
-  });
-}
-
-module.exports = { sendErrorToChannel, registerGlobalErrorHandlers };
+module.exports = { sendErrorToChannel };

--- a/src/utils/send-error.js
+++ b/src/utils/send-error.js
@@ -1,23 +1,25 @@
 require('dotenv').config();
 const { translateLanguage } = require('../languages/index');
 
-async function sendErrorToChannel(source, title, error, additionalInfo = {}) {
-  let client, commandName, user;
+async function sendErrorToChannel(source, error, additionalInfo = {}) {
+  const title = translateLanguage('sendChannelError.error');
+
+  let client, commandName, user, interaction;
+  const unknownUserText = translateLanguage('sendChannelError.unknownUser');
 
   if (source && source.client && source.commandName) {
     client = source.client;
     commandName =
       source.commandName ||
       translateLanguage('sendChannelError.unknownCommand');
-    user = source.user
-      ? source.user.tag
-      : translateLanguage('sendChannelError.unknownUser');
+    user = source.user ? source.user.tag : unknownUserText;
+    interaction = source;
   } else {
     client = source;
     commandName =
       additionalInfo.command ||
       translateLanguage('sendChannelError.unknownFunction');
-    user = translateLanguage('sendChannelError.unknownUser');
+    user = unknownUserText;
   }
 
   const errorChannelID = process.env.ERROR_CHANNEL_ID;
@@ -30,30 +32,56 @@ async function sendErrorToChannel(source, title, error, additionalInfo = {}) {
 
   let message = `**${title}**\n`;
   message += `**${translateLanguage('sendChannelError.commandLabel')}** ${commandName}\n`;
-  message += `**${translateLanguage('sendChannelError.userLabel')}** ${user}\n`;
+
+  if (user !== unknownUserText) {
+    message += `**${translateLanguage('sendChannelError.userLabel')}** ${user}\n`;
+  }
+
   if (additionalInfo.channel) {
     message += `**${translateLanguage('sendChannelError.channelLabel')}** ${additionalInfo.channel}\n`;
   }
-  message += `**${translateLanguage('sendChannelError.errorLabel')}** \`\`\`js\n${error.stack || error}\n\`\`\``;
+
+  message += `**${translateLanguage('sendChannelError.errorLabel')}** \`\`\`js\n${
+    error.stack || error
+  }\n\`\`\``;
 
   try {
     await errorChannel.send(message);
   } catch (err) {
     console.error(translateLanguage('sendChannelError.couldNotSend'), err);
   }
+
+  if (interaction && interaction.isRepliable()) {
+    try {
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({
+          content: translateLanguage('sendChannelError.userMessage'),
+          ephemeral: true,
+        });
+      } else {
+        await interaction.followUp({
+          content: translateLanguage('sendChannelError.userMessage'),
+          ephemeral: true,
+        });
+      }
+    } catch (err) {
+      console.error(
+        translateLanguage('sendChannelError.couldNotSendToUser'),
+        err
+      );
+    }
+  }
 }
 
 function registerGlobalErrorHandlers(client) {
   process.on('uncaughtException', async (error) => {
     console.error('Unhandled Exception:', error);
-    await sendErrorToChannel(client, 'Unhandled Exception', error);
+    await sendErrorToChannel(client, error);
   });
 
   process.on('unhandledRejection', async (reason, promise) => {
     console.error('Unhandled Rejection at:', promise, 'reason:', reason);
-    await sendErrorToChannel(client, 'Unhandled Rejection', reason, {
-      promise,
-    });
+    await sendErrorToChannel(client, reason, { promise });
   });
 }
 

--- a/src/utils/send-error.js
+++ b/src/utils/send-error.js
@@ -29,6 +29,21 @@ async function sendErrorToChannel(source, error, additionalInfo = {}) {
 
   if (!errorChannel || !errorChannel.isTextBased()) {
     console.error(translateLanguage('sendChannelError.channelNotFound'));
+
+    if (interaction && interaction.replied === false) {
+      try {
+        await interaction.reply({
+          content: translateLanguage('sendChannelError.channelNotFound'),
+          ephemeral: true,
+        });
+      } catch (err) {
+        console.error(
+          translateLanguage('sendChannelError.couldNotSendToUser'),
+          err
+        );
+      }
+    }
+
     return;
   }
 
@@ -77,9 +92,9 @@ function registerGlobalErrorHandlers(client) {
     await sendErrorToChannel(client, error);
   });
 
-  process.on('unhandledRejection', async (reason, promise) => {
-    console.error('Unhandled Rejection at:', promise, 'reason:', reason);
-    await sendErrorToChannel(client, reason, { promise });
+  process.on('unhandledRejection', async (reason) => {
+    console.error('Unhandled Rejection:', reason);
+    await sendErrorToChannel(client, reason);
   });
 }
 

--- a/src/utils/send-error.js
+++ b/src/utils/send-error.js
@@ -1,4 +1,3 @@
-// utils/sendError.js
 require('dotenv').config();
 const { translateLanguage } = require('../languages/index');
 
@@ -13,7 +12,6 @@ const { translateLanguage } = require('../languages/index');
 async function sendErrorToChannel(source, title, error, additionalInfo = {}) {
   let client, commandName, user;
 
-  // If "source" has interaction properties, it is assumed to be an interaction.
   if (source && source.client && source.commandName) {
     client = source.client;
     commandName =
@@ -23,7 +21,6 @@ async function sendErrorToChannel(source, title, error, additionalInfo = {}) {
       ? source.user.tag
       : translateLanguage('sendChannelError.unknownUser');
   } else {
-    // Otherwise, it is assumed that "source" is a client directly.
     client = source;
     commandName =
       additionalInfo.command ||
@@ -32,7 +29,6 @@ async function sendErrorToChannel(source, title, error, additionalInfo = {}) {
       additionalInfo.user || translateLanguage('sendChannelError.unknownUser');
   }
 
-  // Ensure additionalInfo has the command or function name.
   additionalInfo.command = commandName;
 
   const errorChannelID = process.env.ERROR_CHANNEL_ID;
@@ -43,7 +39,6 @@ async function sendErrorToChannel(source, title, error, additionalInfo = {}) {
     return;
   }
 
-  // Format the error message
   let message = `**${title}**\n`;
   message += `**${translateLanguage('sendChannelError.commandLabel')}** ${commandName}\n`;
   message += `**${translateLanguage('sendChannelError.userLabel')}** ${user}\n`;

--- a/src/utils/send-error.js
+++ b/src/utils/send-error.js
@@ -1,25 +1,27 @@
 require('dotenv').config();
 const { translateLanguage } = require('../languages/index');
+const { getGitHubIssueURL } = require('./githubIssue');
 
 async function sendErrorToChannel(source, error, additionalInfo = {}) {
   const title = translateLanguage('sendChannelError.error');
 
   let client, commandName, user, interaction;
-  const unknownUserText = translateLanguage('sendChannelError.unknownUser');
 
   if (source && source.client && source.commandName) {
     client = source.client;
     commandName =
       source.commandName ||
       translateLanguage('sendChannelError.unknownCommand');
-    user = source.user ? source.user.tag : unknownUserText;
+    user = source.user
+      ? source.user.tag
+      : translateLanguage('sendChannelError.unknownUser');
     interaction = source;
   } else {
     client = source;
     commandName =
       additionalInfo.command ||
       translateLanguage('sendChannelError.unknownFunction');
-    user = unknownUserText;
+    user = translateLanguage('sendChannelError.unknownUser');
   }
 
   const errorChannelID = process.env.ERROR_CHANNEL_ID;
@@ -33,7 +35,7 @@ async function sendErrorToChannel(source, error, additionalInfo = {}) {
   let message = `**${title}**\n`;
   message += `**${translateLanguage('sendChannelError.commandLabel')}** ${commandName}\n`;
 
-  if (user !== unknownUserText) {
+  if (user !== translateLanguage('sendChannelError.unknownUser')) {
     message += `**${translateLanguage('sendChannelError.userLabel')}** ${user}\n`;
   }
 
@@ -41,9 +43,12 @@ async function sendErrorToChannel(source, error, additionalInfo = {}) {
     message += `**${translateLanguage('sendChannelError.channelLabel')}** ${additionalInfo.channel}\n`;
   }
 
-  message += `**${translateLanguage('sendChannelError.errorLabel')}** \`\`\`js\n${
-    error.stack || error
-  }\n\`\`\``;
+  message += `**${translateLanguage('sendChannelError.errorLabel')}** \`\`\`js\n${error.stack || error}\n\`\`\``;
+
+  const issueUrl = getGitHubIssueURL(error.stack || error);
+  if (issueUrl) {
+    message += `\n🔗 **${translateLanguage('sendChannelError.reportIssue')}**: [${translateLanguage('sendChannelError.clickHere')}](${issueUrl})`;
+  }
 
   try {
     await errorChannel.send(message);
@@ -53,17 +58,10 @@ async function sendErrorToChannel(source, error, additionalInfo = {}) {
 
   if (interaction && interaction.isRepliable()) {
     try {
-      if (!interaction.replied && !interaction.deferred) {
-        await interaction.reply({
-          content: translateLanguage('sendChannelError.userMessage'),
-          ephemeral: true,
-        });
-      } else {
-        await interaction.followUp({
-          content: translateLanguage('sendChannelError.userMessage'),
-          ephemeral: true,
-        });
-      }
+      await interaction.followUp({
+        content: translateLanguage('sendChannelError.userMessage'),
+        ephemeral: true,
+      });
     } catch (err) {
       console.error(
         translateLanguage('sendChannelError.couldNotSendToUser'),

--- a/src/utils/send-error.js
+++ b/src/utils/send-error.js
@@ -86,12 +86,10 @@ async function sendErrorToChannel(source, error, additionalInfo = {}) {
 
 function registerGlobalErrorHandlers(client) {
   process.on('uncaughtException', async (error) => {
-    console.error('Unhandled Exception:', error);
     await sendErrorToChannel(client, error);
   });
 
   process.on('unhandledRejection', async (reason) => {
-    console.error('Unhandled Rejection:', reason);
     await sendErrorToChannel(client, reason);
   });
 }

--- a/src/utils/send-error.js
+++ b/src/utils/send-error.js
@@ -20,8 +20,6 @@ async function sendErrorToChannel(source, title, error, additionalInfo = {}) {
     user = translateLanguage('sendChannelError.unknownUser');
   }
 
-  additionalInfo.command = commandName;
-
   const errorChannelID = process.env.ERROR_CHANNEL_ID;
   const errorChannel = client.channels.cache.get(errorChannelID);
 


### PR DESCRIPTION
This PR implements a unified error reporting function (sendErrorToChannel) that automatically logs errors from both commands and cron jobs to a designated error channel. The implementation uses translation keys to support multilingual messages (English/Spanish).

Key Changes:

- utils/send-error.js:
  -  A new function sendErrorToChannel now extracts dynamic data (command/function name, user or bot tag) from either an interaction or directly from the client.
  -  Hardcoded texts have been replaced with calls to translateLanguage for labels such as "Command/Function", "User", "Channel", and "Error".

- Error Reporting:
   - Errors from both commands and cron jobs are now automatically sent to the error channel defined by ERROR_CHANNEL_ID in the .env file.


- Translation Support:
   - Added/updated translation keys in both English and Spanish (e.g., sendChannelError.commandLabel, sendChannelError.userLabel, etc.).