### PR TITLE
fix: restore pr template modal handler

### DIFF
--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -1,5 +1,6 @@
 const { Events } = require('discord.js');
 const { translateLanguage } = require('../languages');
+const { handleModalSubmit } = require('../handlers/modal-submit');
 
 module.exports = {
   name: Events.InteractionCreate,
@@ -50,24 +51,26 @@ module.exports = {
         }
       }
     } else if (interaction.isModalSubmit()) {
-      if (interaction.customId === 'edit_reminder_modal') {
-        const command = interaction.client.commands.get('remindme');
+      try {
+        if (interaction.customId === 'edit_reminder_modal') {
+          const command = interaction.client.commands.get('remindme');
 
-        if (!command) {
-          console.error('No command matching remindme was found.');
-          return;
-        }
-
-        try {
-          await command.buttonHandler(interaction);
-        } catch (error) {
-          console.error('Error handling modal submit:', error);
-          if (!interaction.replied && !interaction.deferred) {
-            await interaction.reply({
-              content: translateLanguage('interaction.errorSubmission'),
-              ephemeral: true,
-            });
+          if (!command) {
+            console.error('No command matching remindme was found.');
+            return;
           }
+
+          await command.buttonHandler(interaction);
+        } else {
+          await handleModalSubmit(interaction);
+        }
+      } catch (error) {
+        console.error('Error handling modal submit:', error);
+        if (!interaction.replied && !interaction.deferred) {
+          await interaction.reply({
+            content: translateLanguage('interaction.errorSubmission'),
+            ephemeral: true,
+          });
         }
       }
     }


### PR DESCRIPTION
### Description
This PR restores the previously removed PR template modal functionality the modal can now be used again to create new PRs with pre-filled templates, improving consistency and reducing manual effort.

Fixes:
 - #128 

#### Type of change

- [x] Fix feature (non-breaking change which fix functionality)

### Checklist
 This issue can be closed when the following tasks are complete:

 - [x] It creates a message in the channel selected

### Screenshots
>
![Uploading image.png…]()

