### PR TITLE
fix: slice report message

### DIFF
--- a/src/languages/translations/en.json
+++ b/src/languages/translations/en.json
@@ -153,6 +153,7 @@
   },
   "sendChannelError": {
     "error": "An error occurred you can pass this location to the technical service",
+    "errorReport": "Click here to report it to technical service",
     "couldNotSendToUser": "Could not send an error message to the user.",
     "unknownCommand": "unknown command",
     "unknownUser": "unknown user",

--- a/src/languages/translations/es.json
+++ b/src/languages/translations/es.json
@@ -154,6 +154,7 @@
   },
   "sendChannelError": {
     "error": "Ocurrió un error puedes pasar esta ubicación al servicio técnico",
+    "errorReport": "Haga clic aquí para informarlo al servicio técnico",
     "noSePudoEnviarAlUsuario": "No se pudo enviar un mensaje de error al usuario.",
     "unknownCommand": "comando desconocido",
     "unknownUser": "usuario desconocido",

--- a/src/utils/send-error.js
+++ b/src/utils/send-error.js
@@ -1,13 +1,95 @@
 require('dotenv').config();
+const { EmbedBuilder } = require('discord.js');
 const { translateLanguage } = require('../languages/index');
 const { getGitHubIssueURL } = require('./githubIssue');
 
-const MAX_MESSAGE_LENGTH = 300;
-const MAX_MESSAGE_REPORT_LENGTH = 1000;
+/**
+ * Maximum character length for a Discord embed description.
+ *
+ * This constant is based on the limit defined by Discord's API.
+ * Exceeding this limit will result in an error when attempting to send the embed.
+ *
+ * @see {@link https://discordjs.guide/popular-topics/embeds.html#embed-limits}
+ * @type {number}
+ */
+const MAX_EMBED_MESSAGE_DESCRIPTION_LENGTH = 4096;
+
+/**
+ * Maximum character length for an error message (regular message).
+ *
+ * This constant defines the upper limit for the length of error messages
+ * sent to Discord (regular text messages).
+ * It's used to prevent exceeding Discord's normal message size limits and ensure that
+ * error reports are delivered successfully.
+ *
+ * @type {number}
+ */
+const MAX_ERROR_MESSAGE_LENGTH = 1000;
+
+const GITHUB_IMAGE_LOGO =
+  'https://github.githubassets.com/assets/github-mark-57519b92ca4e.png';
+
+function buildErrorMessage({ error, commandName, user, additionalInfo }) {
+  const title = `Error: ${error.message.slice(0, 200)}. ${translateLanguage('sendChannelError.errorReport')}`;
+  const errorStack = (error.stack || error).toString();
+  const gitHubIssueURL = getGitHubIssueURL(errorStack);
+
+  if (errorStack.length >= MAX_ERROR_MESSAGE_LENGTH) {
+    const embedMessage = new EmbedBuilder()
+      .setColor('#0099ff')
+      .setTitle(`**${title}**\n`)
+      .setThumbnail(GITHUB_IMAGE_LOGO)
+      .setURL(gitHubIssueURL)
+      .setDescription(
+        `
+        **${translateLanguage('sendChannelError.commandLabel')}** ${commandName}\n
+        ${
+          user !== translateLanguage('sendChannelError.unknownUser')
+            ? `**${translateLanguage('sendChannelError.userLabel')}** ${user}\n`
+            : ''
+        }
+        ${
+          additionalInfo.channel
+            ? `**${translateLanguage('sendChannelError.channelLabel')}** ${additionalInfo.channel}\n`
+            : ''
+        }
+
+        **${translateLanguage('sendChannelError.errorLabel')}** \`\`\`js\n${errorStack}\n\`\`\`
+
+        ${
+          gitHubIssueURL
+            ? `\n🔗 **${translateLanguage('sendChannelError.reportIssue')}**: [${translateLanguage('sendChannelError.clickHere')}](${gitHubIssueURL})`
+            : ''
+        }
+        `.slice(0, MAX_EMBED_MESSAGE_DESCRIPTION_LENGTH)
+      );
+
+    return embedMessage;
+  }
+
+  let message = `**${title}**\n`;
+  message += `**${translateLanguage('sendChannelError.commandLabel')}** ${commandName}\n`;
+
+  if (user !== translateLanguage('sendChannelError.unknownUser')) {
+    message += `**${translateLanguage('sendChannelError.userLabel')}** ${user}\n`;
+  }
+
+  if (additionalInfo.channel) {
+    message += `**${translateLanguage('sendChannelError.channelLabel')}** ${additionalInfo.channel}\n`;
+  }
+
+  message += `**${translateLanguage('sendChannelError.errorLabel')}** \`\`\`js\n${errorStack}\n\`\`\``;
+
+  const issueUrl = getGitHubIssueURL(errorStack);
+
+  if (issueUrl) {
+    message += `\n🔗 **${translateLanguage('sendChannelError.reportIssue')}**: [${translateLanguage('sendChannelError.clickHere')}](${issueUrl})`;
+  }
+
+  return message;
+}
 
 async function sendErrorToChannel(source, error, additionalInfo = {}) {
-  const title = translateLanguage('sendChannelError.error');
-
   let client, commandName, user, interaction;
 
   if (source && source.client && source.commandName) {
@@ -48,29 +130,17 @@ async function sendErrorToChannel(source, error, additionalInfo = {}) {
     return;
   }
 
-  let message = `**${title}**\n`;
-  message += `**${translateLanguage('sendChannelError.commandLabel')}** ${commandName}\n`;
-
-  if (user !== translateLanguage('sendChannelError.unknownUser')) {
-    message += `**${translateLanguage('sendChannelError.userLabel')}** ${user}\n`;
-  }
-
-  if (additionalInfo.channel) {
-    message += `**${translateLanguage('sendChannelError.channelLabel')}** ${additionalInfo.channel}\n`;
-  }
-
-  const errorPreview = `${(error.stack || error).toString().slice(0, MAX_MESSAGE_LENGTH)}...`;
-  const sliceErrorReport = `${(error.stack || error).toString().slice(0, MAX_MESSAGE_REPORT_LENGTH)}...`;
-
-  message += `**${translateLanguage('sendChannelError.errorLabel')}** \`\`\`js\n${errorPreview}\n\`\`\``;
-
-  const issueUrl = getGitHubIssueURL(sliceErrorReport);
-  if (issueUrl) {
-    message += `\n🔗 **${translateLanguage('sendChannelError.reportIssue')}**: [${translateLanguage('sendChannelError.clickHere')}](${issueUrl})`;
-  }
+  const errorMessage = buildErrorMessage({
+    error,
+    commandName,
+    user,
+    additionalInfo,
+  });
 
   try {
-    await errorChannel.send(message);
+    await errorChannel.send(
+      errorMessage.data ? { embeds: [errorMessage] } : errorMessage
+    );
   } catch (err) {
     console.error(translateLanguage('sendChannelError.couldNotSend'), err);
   }

--- a/src/utils/send-error.js
+++ b/src/utils/send-error.js
@@ -2,6 +2,9 @@ require('dotenv').config();
 const { translateLanguage } = require('../languages/index');
 const { getGitHubIssueURL } = require('./githubIssue');
 
+const MAX_MESSAGE_LENGTH = 300;
+const MAX_MESSAGE_REPORT_LENGTH = 1000;
+
 async function sendErrorToChannel(source, error, additionalInfo = {}) {
   const title = translateLanguage('sendChannelError.error');
 
@@ -56,9 +59,12 @@ async function sendErrorToChannel(source, error, additionalInfo = {}) {
     message += `**${translateLanguage('sendChannelError.channelLabel')}** ${additionalInfo.channel}\n`;
   }
 
-  message += `**${translateLanguage('sendChannelError.errorLabel')}** \`\`\`js\n${error.stack || error}\n\`\`\``;
+  const errorPreview = `${(error.stack || error).toString().slice(0, MAX_MESSAGE_LENGTH)}...`;
+  const sliceErrorReport = `${(error.stack || error).toString().slice(0, MAX_MESSAGE_REPORT_LENGTH)}...`;
 
-  const issueUrl = getGitHubIssueURL(error.stack || error);
+  message += `**${translateLanguage('sendChannelError.errorLabel')}** \`\`\`js\n${errorPreview}\n\`\`\``;
+
+  const issueUrl = getGitHubIssueURL(sliceErrorReport);
   if (issueUrl) {
     message += `\n🔗 **${translateLanguage('sendChannelError.reportIssue')}**: [${translateLanguage('sendChannelError.clickHere')}](${issueUrl})`;
   }


### PR DESCRIPTION
### Description
Improve error messages to comply with Discord's character limit. This PR addresses an issue where error reports from the Discord bot were exceeding Discord's message character limit. Error messages are now converted to embed message to ensure they can be successfully delivered.
- Added a function that check length string and decide to create an embed message or regular depending on maximum length.
- Applied this function to error messages before sending them to Discord.

Fixes:
 - #131 

#### Type of change

- [x] Fix feature (non-breaking change which fix functionality)

### Checklist
 This issue can be closed when the following tasks are complete:

 - [x] It generate a message in the report error channel when fail

### Screenshots
- Regular message
>![image](https://github.com/user-attachments/assets/bc8b072d-69d0-46e9-b6fe-9a99b8923be0)
- Embed message
>
![image](https://github.com/user-attachments/assets/03549008-e7b3-4f05-b874-6ddc0819f8f2)

