### PR TITLE
fix: sustract minutes to the start date event

### DIFF
--- a/src/cron/schedule-google-calendar.js
+++ b/src/cron/schedule-google-calendar.js
@@ -7,7 +7,7 @@ const { FIREBASE_CONFIG } = require('../config');
 
 let activeCronJobs = [];
 
-const minutesBeforeEvent = 10 * 60 * 1000;
+const minutesBeforeEvent = 10;
 
 const clearAllCronJobs = () => {
   activeCronJobs.forEach((job) => job.stop());
@@ -37,7 +37,7 @@ const scheduleEventNotification = async ({ client, event }) => {
   }
 
   const startDate = new Date(event.start.dateTime);
-  startDate.setTime(startDate.getTime() - minutesBeforeEvent);
+  startDate.setMinutes(startDate.getMinutes() - minutesBeforeEvent);
 
   const cronExpression = dateToCronExpression(startDate);
   const job = new CronJob(

--- a/src/cron/schedule-google-calendar.js
+++ b/src/cron/schedule-google-calendar.js
@@ -7,6 +7,8 @@ const { FIREBASE_CONFIG } = require('../config');
 
 let activeCronJobs = [];
 
+const minutesBeforeEvent = 10 * 60 * 1000;
+
 const clearAllCronJobs = () => {
   activeCronJobs.forEach((job) => job.stop());
   activeCronJobs = [];
@@ -34,7 +36,10 @@ const scheduleEventNotification = async ({ client, event }) => {
     );
   }
 
-  const cronExpression = dateToCronExpression(event.start.dateTime);
+  const startDate = new Date(event.start.dateTime);
+  startDate.setTime(startDate.getTime() - minutesBeforeEvent);
+
+  const cronExpression = dateToCronExpression(startDate);
   const job = new CronJob(
     cronExpression,
     async () => {


### PR DESCRIPTION
### Description
This PR corrects the event reporting timing.  Reminders are now scheduled and sent 10 minutes before the event's start time, rather than at the moment the event begins.
- Implemented logic to calculate and schedule reminders 10 minutes before the event start time.
- Updated the reminder sending mechanism to use the new schedule.

Fixes:
 - #124 

#### Type of change

- [x] Fix feature (non-breaking change which fix functionality)

### Checklist
 This issue can be closed when the following tasks are complete:

 - [x] It report notification a minutes before the event start

### Screenshots
- Event
>![image](https://github.com/user-attachments/assets/716ca844-800a-4ab1-a7c7-a13701177b6c)

- Reminder
>![image](https://github.com/user-attachments/assets/36605281-ff2d-4fae-81bb-05df72f54b1e)


