### PR TITLE
feat: incorrect date range in my points query

### DIFF
--- a/src/commands/utility/search-my-points.js
+++ b/src/commands/utility/search-my-points.js
@@ -48,8 +48,8 @@ module.exports = {
         ? channelsInput.split(',').map((channel) => channel.trim())
         : [];
 
-      const targetStartDate = new Date(year, month - 1, 0);
-      const targetEndDate = new Date(year, month, 1);
+      const targetStartDate = new Date(year, month - 1, 1);
+      const targetEndDate = new Date(year, month, 0);
 
       const startDateStr = `${targetStartDate.getFullYear()}-${String(
         targetStartDate.getMonth() + 1


### PR DESCRIPTION
This PR fixes a bug in the /my-points-query command, where the date range used did not match the one in /my-points.

/my-points correctly uses:
```js
const targetStartDate = new Date(year, month - 1, 1);
const targetEndDate = new Date(year, month, 0);
This covers the first to last day of the month.
```

/my-points-query was using:

```js
const targetStartDate = new Date(year, month - 1, 0);
const targetEndDate = new Date(year, month, 1);

```

This caused the range to include the last day of the previous month and the first day of the next month, causing discrepancies in the results.

Solution:
Modify /my-points-query to use the same date range as /my-points:
