### PR TITLE
Manual Assign Points Command

### DIFF
--- a/src/commands/commandList.js
+++ b/src/commands/commandList.js
@@ -12,6 +12,7 @@ const sendMessageCommand = require('./utility/send-message');
 const serverCommand = require('./utility/server');
 const userCommand = require('./utility/user');
 const votePointsCommand = require('./utility/vote-points');
+const assingPointCommand = require('./utility/assignPoint');
 
 const commandList = [
   pingCommand,
@@ -28,5 +29,6 @@ const commandList = [
   serverCommand,
   userCommand,
   votePointsCommand,
+  assingPointCommand,
 ];
 module.exports = commandList;

--- a/src/commands/utility/assignPoint.js
+++ b/src/commands/utility/assignPoint.js
@@ -2,8 +2,6 @@ const { SlashCommandBuilder } = require('discord.js');
 const { sendErrorToChannel } = require('../../utils/send-error');
 const { VOTE_POINTS, ADMIN_ROLE_ID } = require('../../config');
 const { translateLanguage, keyTranslations } = require('../../languages');
-const tagIds = VOTE_POINTS.TAG_IDS;
-const adminRoleId = ADMIN_ROLE_ID.adminRole;
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -50,7 +48,7 @@ module.exports = {
     ),
 
   async execute(interaction) {
-    if (!interaction.member.roles.cache.has(adminRoleId)) {
+    if (!interaction.member.roles.cache.has(ADMIN_ROLE_ID.adminRole)) {
       return interaction.reply({
         content: translateLanguage('assignPoints.noPermission'),
         ephemeral: true,
@@ -62,9 +60,10 @@ module.exports = {
       reason = interaction.options.getString('reason'),
       tagId =
         pointType === 'boosted'
-          ? tagIds.boostedPointTagId
-          : tagIds.addPointTagId,
+          ? VOTE_POINTS.TAG_IDS.boostedPointTagId
+          : VOTE_POINTS.TAG_IDS.addPointTagId,
       roleMention = `<@&${tagId}>`;
+
     try {
       await interaction.reply({
         content: translateLanguage('assignPoints.orderReceived', {

--- a/src/commands/utility/assignPoint.js
+++ b/src/commands/utility/assignPoint.js
@@ -1,0 +1,93 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { sendErrorToChannel } = require('../../utils/send-error');
+const { VOTE_POINTS, ADMIN_ROLE_ID } = require('../../config');
+const { translateLanguage, keyTranslations } = require('../../languages');
+const tagIds = VOTE_POINTS.TAG_IDS;
+const adminRoleId = ADMIN_ROLE_ID.adminRole;
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('assign-points')
+    .setDescription(translateLanguage('assignPoints.description'))
+    .setDescriptionLocalizations(keyTranslations('assignPoints.description'))
+    .addUserOption((option) =>
+      option
+        .setName('user')
+        .setDescription(translateLanguage('assignPoints.userOption'))
+        .setDescriptionLocalizations(keyTranslations('assignPoints.userOption'))
+        .setRequired(true)
+    )
+    .addStringOption((option) =>
+      option
+        .setName('point-type')
+        .setDescription(translateLanguage('assignPoints.pointTypeOption'))
+        .setDescriptionLocalizations(
+          keyTranslations('assignPoints.pointTypeOption')
+        )
+        .setRequired(true)
+        .addChoices(
+          { name: 'Normal Points', value: 'normal' },
+          { name: 'Boosted Points', value: 'boosted' }
+        )
+    )
+    .addIntegerOption((option) =>
+      option
+        .setName('quantity')
+        .setDescription(translateLanguage('assignPoints.quantityOption'))
+        .setDescriptionLocalizations(
+          keyTranslations('assignPoints.quantityOption')
+        )
+        .setRequired(true)
+    )
+    .addStringOption((option) =>
+      option
+        .setName('reason')
+        .setDescription(translateLanguage('assignPoints.reasonOption'))
+        .setDescriptionLocalizations(
+          keyTranslations('assignPoints.reasonOption')
+        )
+        .setRequired(true)
+    ),
+
+  async execute(interaction) {
+    if (!interaction.member.roles.cache.has(adminRoleId)) {
+      return interaction.reply({
+        content: translateLanguage('assignPoints.noPermission'),
+        ephemeral: true,
+      });
+    }
+    const targetUser = interaction.options.getUser('user'),
+      pointType = interaction.options.getString('point-type'),
+      quantity = interaction.options.getInteger('quantity'),
+      reason = interaction.options.getString('reason'),
+      tagId =
+        pointType === 'boosted'
+          ? tagIds.boostedPointTagId
+          : tagIds.addPointTagId,
+      roleMention = `<@&${tagId}>`;
+    try {
+      await interaction.reply({
+        content: translateLanguage('assignPoints.orderReceived', {
+          quantity,
+          pointType,
+          target: targetUser.tag,
+        }),
+        ephemeral: true,
+      });
+
+      const pointsLines = Array.from(
+        { length: quantity },
+        () => `${roleMention} ${targetUser}`
+      ).join('\n');
+      const fullMessage = `${pointsLines}\n\n${translateLanguage('assignPoints.reasonLabel')}\n${reason}\n\nBy ${interaction.user}`;
+
+      await interaction.channel.send(fullMessage);
+    } catch (error) {
+      await sendErrorToChannel(interaction, error);
+      return interaction.reply({
+        content: translateLanguage('assignPoints.errorAssigning'),
+        ephemeral: true,
+      });
+    }
+  },
+};

--- a/src/commands/utility/assignPoint.js
+++ b/src/commands/utility/assignPoint.js
@@ -24,8 +24,14 @@ module.exports = {
         )
         .setRequired(true)
         .addChoices(
-          { name: 'Normal Points', value: 'normal' },
-          { name: 'Boosted Points', value: 'boosted' }
+          {
+            name: translateLanguage('assignPoints.normalPoints'),
+            value: 'normal',
+          },
+          {
+            name: translateLanguage('assignPoints.boostedPoints'),
+            value: 'boosted',
+          }
         )
     )
     .addIntegerOption((option) =>

--- a/src/commands/utility/assignPoint.js
+++ b/src/commands/utility/assignPoint.js
@@ -74,13 +74,13 @@ module.exports = {
         ephemeral: true,
       });
 
-      const pointsLines = Array.from(
-        { length: quantity },
-        () => `${roleMention} ${targetUser}`
-      ).join('\n');
-      const fullMessage = `${pointsLines}\n\n${translateLanguage('assignPoints.reasonLabel')}\n${reason}\n\nBy ${interaction.user}`;
+      for (let i = 0; i < quantity; i++) {
+        await interaction.channel.send(`${roleMention} ${targetUser}`);
+      }
 
-      await interaction.channel.send(fullMessage);
+      await interaction.channel.send(
+        `${translateLanguage('assignPoints.reasonLabel')}\n${reason}\n\nBy ${interaction.user}`
+      );
     } catch (error) {
       await sendErrorToChannel(interaction, error);
       return interaction.reply({

--- a/src/config.js
+++ b/src/config.js
@@ -147,6 +147,9 @@ const FIREBASE_CONFIG = {
   email: process.env.GOOGLE_EMAIL,
   channelCalendarId: process.env.CHANNEL_CALENDAR_ID,
 };
+const ADMIN_ROLE_ID = {
+  adminRole: process.env.ADMIN_ROLE_ID || '1014267063788908585',
+};
 
 module.exports = {
   LISTEN_NEW_EVENTS,
@@ -162,4 +165,5 @@ module.exports = {
   GEMINI_INTEGRATION,
   CRON_STATUS_REMINDER,
   FIREBASE_CONFIG,
+  ADMIN_ROLE_ID,
 };

--- a/src/languages/translations/en-US.json
+++ b/src/languages/translations/en-US.json
@@ -211,6 +211,8 @@
     "noPermission": "You don't have permission to use this command.",
     "orderReceived": "Order received. Assigning {{quantity}} {{pointType}} point(s) to {{target}}.",
     "reasonLabel": "Reason:",
-    "errorAssigning": "There was an error assigning points. Please try again later."
+    "errorAssigning": "There was an error assigning points. Please try again later.",
+    "normalPoints": "Normal Points",
+    "boostedPoints": "Boosted Points"
   }
 }

--- a/src/languages/translations/en-US.json
+++ b/src/languages/translations/en-US.json
@@ -200,5 +200,17 @@
   "interaction": {
     "errorButton": "There was an error processing your button interaction.",
     "errorSubmission": "There was an error processing your submission."
+  },
+
+  "assignPoints": {
+    "description": "Manually assign points to a user (admin role only)",
+    "userOption": "User who will receive the points",
+    "pointTypeOption": "Type of points to assign",
+    "quantityOption": "Number of points to assign",
+    "reasonOption": "Reason for assigning the point",
+    "noPermission": "You don't have permission to use this command.",
+    "orderReceived": "Order received. Assigning {{quantity}} {{pointType}} point(s) to {{target}}.",
+    "reasonLabel": "Reason:",
+    "errorAssigning": "There was an error assigning points. Please try again later."
   }
 }

--- a/src/languages/translations/es-ES.json
+++ b/src/languages/translations/es-ES.json
@@ -201,5 +201,17 @@
   "interaction": {
     "errorButton": "Hubo un error al procesar la interacción del botón.",
     "errorSubmission": "Hubo un error al procesar tu envío."
+  },
+
+  "assignPoints": {
+    "description": "Asignar puntos manualmente a un usuario (solo rol admin)",
+    "userOption": "Usuario que recibirá los puntos",
+    "pointTypeOption": "Tipo de puntos a asignar",
+    "cantidadOption": "Cantidad de puntos a asignar",
+    "reasonOption": "Razón para asignar el punto",
+    "noPermission": "No tienes permiso para usar este comando.",
+    "orderReceived": "Orden recibida. Asignando {{quantity}} {{pointType}} punto(s) a {{target}}.",
+    "reasonLabel": "Razón:",
+    "errorAssigning": "Hubo un error al asignar puntos. Por favor, intenta de nuevo más tarde."
   }
 }

--- a/src/languages/translations/es-ES.json
+++ b/src/languages/translations/es-ES.json
@@ -212,6 +212,8 @@
     "noPermission": "No tienes permiso para usar este comando.",
     "orderReceived": "Orden recibida. Asignando {{quantity}} {{pointType}} punto(s) a {{target}}.",
     "reasonLabel": "Razón:",
-    "errorAssigning": "Hubo un error al asignar puntos. Por favor, intenta de nuevo más tarde."
+    "errorAssigning": "Hubo un error al asignar puntos. Por favor, intenta de nuevo más tarde.",
+    "normalPoints": "puntos normales",
+    "boostedPoints": "puntos potenciados"
   }
 }


### PR DESCRIPTION
### This pull request adds a new slash command, /assign-points, which allows administrators (users with the required admin role) to manually assign points to a specified user. Key details include:

Functionality:

- Admins can assign a specific quantity of points (Normal or Boosted) to a user.
- A mandatory reason must be provided.
- When more than one point is assigned, the command sends a single message that repeats the assignment line for each point, then includes a "Reason:" section and the admin's signature.

### Validation:

- The command verifies that the executing user has the correct admin role before processing the assignment.
In case of errors, it sends a notification to an error logging channel using sendErrorToChannel.